### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/110/875/794/1/1108757941.geojson
+++ b/data/110/875/794/1/1108757941.geojson
@@ -47,6 +47,9 @@
     "wof:concordances":{},
     "wof:country":"QA",
     "wof:created":1481308637,
+    "wof:geom_alt":[
+        "meso"
+    ],
     "wof:geomhash":"4214aaad526438e9649be77326c72eaf",
     "wof:hierarchy":[
         {
@@ -57,7 +60,7 @@
         }
     ],
     "wof:id":1108757941,
-    "wof:lastmodified":1566609688,
+    "wof:lastmodified":1582360331,
     "wof:name":"Al Utouriya",
     "wof:parent_id":1377149569,
     "wof:placetype":"county",

--- a/data/110/875/794/5/1108757945.geojson
+++ b/data/110/875/794/5/1108757945.geojson
@@ -41,6 +41,9 @@
     "wof:concordances":{},
     "wof:country":"QA",
     "wof:created":1481308638,
+    "wof:geom_alt":[
+        "meso"
+    ],
     "wof:geomhash":"c865c97f8617841f6a7750a13a2fb3db",
     "wof:hierarchy":[
         {
@@ -51,7 +54,7 @@
         }
     ],
     "wof:id":1108757945,
-    "wof:lastmodified":1566609688,
+    "wof:lastmodified":1582360331,
     "wof:name":"Al Thakhira/Rass Laffan/Umm Birka",
     "wof:parent_id":85676767,
     "wof:placetype":"county",

--- a/data/110/875/794/7/1108757947.geojson
+++ b/data/110/875/794/7/1108757947.geojson
@@ -41,6 +41,9 @@
     "wof:concordances":{},
     "wof:country":"QA",
     "wof:created":1481308640,
+    "wof:geom_alt":[
+        "meso"
+    ],
     "wof:geomhash":"2909654953fb457f11d839d0984a75eb",
     "wof:hierarchy":[
         {
@@ -51,7 +54,7 @@
         }
     ],
     "wof:id":1108757947,
-    "wof:lastmodified":1566609688,
+    "wof:lastmodified":1582360331,
     "wof:name":"Abu Dhalouf/Al Zubara",
     "wof:parent_id":85676773,
     "wof:placetype":"county",

--- a/data/110/875/794/9/1108757949.geojson
+++ b/data/110/875/794/9/1108757949.geojson
@@ -74,6 +74,9 @@
     "wof:concordances":{},
     "wof:country":"QA",
     "wof:created":1481308641,
+    "wof:geom_alt":[
+        "meso"
+    ],
     "wof:geomhash":"c4b83174bdeb975004d442ed63ce36d5",
     "wof:hierarchy":[
         {
@@ -84,7 +87,7 @@
         }
     ],
     "wof:id":1108757949,
-    "wof:lastmodified":1566609687,
+    "wof:lastmodified":1582360331,
     "wof:name":"Umm Bab",
     "wof:parent_id":1377149569,
     "wof:placetype":"county",

--- a/data/110/875/795/1/1108757951.geojson
+++ b/data/110/875/795/1/1108757951.geojson
@@ -80,6 +80,9 @@
     "wof:concordances":{},
     "wof:country":"QA",
     "wof:created":1481308643,
+    "wof:geom_alt":[
+        "meso"
+    ],
     "wof:geomhash":"e4f5813a1c01aa4b42455fc04b7e4ed8",
     "wof:hierarchy":[
         {
@@ -90,7 +93,7 @@
         }
     ],
     "wof:id":1108757951,
-    "wof:lastmodified":1566609688,
+    "wof:lastmodified":1582360331,
     "wof:name":"Dukhan",
     "wof:parent_id":1377149569,
     "wof:placetype":"county",

--- a/data/110/875/795/3/1108757953.geojson
+++ b/data/110/875/795/3/1108757953.geojson
@@ -41,6 +41,9 @@
     "wof:concordances":{},
     "wof:country":"QA",
     "wof:created":1481308644,
+    "wof:geom_alt":[
+        "meso"
+    ],
     "wof:geomhash":"1c7b452c62eed4fe1db1ef9c027f0009",
     "wof:hierarchy":[
         {
@@ -51,7 +54,7 @@
         }
     ],
     "wof:id":1108757953,
-    "wof:lastmodified":1566609688,
+    "wof:lastmodified":1582360331,
     "wof:name":"Al Wakra",
     "wof:parent_id":85676759,
     "wof:placetype":"county",

--- a/data/110/875/795/5/1108757955.geojson
+++ b/data/110/875/795/5/1108757955.geojson
@@ -41,6 +41,9 @@
     "wof:concordances":{},
     "wof:country":"QA",
     "wof:created":1481308645,
+    "wof:geom_alt":[
+        "meso"
+    ],
     "wof:geomhash":"0bd16372d79876af727e8ed2c5bbd533",
     "wof:hierarchy":[
         {
@@ -51,7 +54,7 @@
         }
     ],
     "wof:id":1108757955,
-    "wof:lastmodified":1566609689,
+    "wof:lastmodified":1582360332,
     "wof:name":"Messaid",
     "wof:parent_id":85676759,
     "wof:placetype":"county",

--- a/data/110/875/795/7/1108757957.geojson
+++ b/data/110/875/795/7/1108757957.geojson
@@ -44,6 +44,9 @@
     "wof:concordances":{},
     "wof:country":"QA",
     "wof:created":1481308647,
+    "wof:geom_alt":[
+        "meso"
+    ],
     "wof:geomhash":"b710e03dafb29f81003639d1f108c094",
     "wof:hierarchy":[
         {
@@ -54,7 +57,7 @@
         }
     ],
     "wof:id":1108757957,
-    "wof:lastmodified":1566609688,
+    "wof:lastmodified":1582360331,
     "wof:name":"Mesaieed Industrial Area",
     "wof:parent_id":85676759,
     "wof:placetype":"county",

--- a/data/110/875/795/9/1108757959.geojson
+++ b/data/110/875/795/9/1108757959.geojson
@@ -44,6 +44,9 @@
     "wof:concordances":{},
     "wof:country":"QA",
     "wof:created":1481308648,
+    "wof:geom_alt":[
+        "meso"
+    ],
     "wof:geomhash":"29b379dc689395974ed48a5882708e13",
     "wof:hierarchy":[
         {
@@ -54,7 +57,7 @@
         }
     ],
     "wof:id":1108757959,
-    "wof:lastmodified":1566609688,
+    "wof:lastmodified":1582360331,
     "wof:name":"Abu Samra",
     "wof:parent_id":1377149573,
     "wof:placetype":"county",

--- a/data/110/875/796/3/1108757963.geojson
+++ b/data/110/875/796/3/1108757963.geojson
@@ -41,6 +41,9 @@
     "wof:concordances":{},
     "wof:country":"QA",
     "wof:created":1481308649,
+    "wof:geom_alt":[
+        "meso"
+    ],
     "wof:geomhash":"18aa548edd38d6f6b7bdccd1b83fa18d",
     "wof:hierarchy":[
         {
@@ -51,7 +54,7 @@
         }
     ],
     "wof:id":1108757963,
-    "wof:lastmodified":1566609683,
+    "wof:lastmodified":1582360330,
     "wof:name":"Jabal Thuaileb/Al Kharayej/Lusail/Al Egla/Wadi Al Banat",
     "wof:parent_id":85676781,
     "wof:placetype":"county",

--- a/data/110/875/808/3/1108758083.geojson
+++ b/data/110/875/808/3/1108758083.geojson
@@ -41,6 +41,9 @@
     "wof:concordances":{},
     "wof:country":"QA",
     "wof:created":1481308719,
+    "wof:geom_alt":[
+        "meso"
+    ],
     "wof:geomhash":"931a87922b107b222a4370080b0b15d0",
     "wof:hierarchy":[
         {
@@ -51,7 +54,7 @@
         }
     ],
     "wof:id":1108758083,
-    "wof:lastmodified":1566609692,
+    "wof:lastmodified":1582360332,
     "wof:name":"Al Ghuwairiya",
     "wof:parent_id":85676767,
     "wof:placetype":"county",

--- a/data/110/875/808/9/1108758089.geojson
+++ b/data/110/875/808/9/1108758089.geojson
@@ -44,6 +44,9 @@
     "wof:concordances":{},
     "wof:country":"QA",
     "wof:created":1481308722,
+    "wof:geom_alt":[
+        "meso"
+    ],
     "wof:geomhash":"71b0c858ae04f394b59f39669015683a",
     "wof:hierarchy":[
         {
@@ -54,7 +57,7 @@
         }
     ],
     "wof:id":1108758089,
-    "wof:lastmodified":1566609692,
+    "wof:lastmodified":1582360332,
     "wof:name":"Al Karaana",
     "wof:parent_id":1377149573,
     "wof:placetype":"county",

--- a/data/110/875/809/3/1108758093.geojson
+++ b/data/110/875/809/3/1108758093.geojson
@@ -41,6 +41,9 @@
     "wof:concordances":{},
     "wof:country":"QA",
     "wof:created":1481308724,
+    "wof:geom_alt":[
+        "meso"
+    ],
     "wof:geomhash":"6632031df8d166b26ec65f3a447e22a7",
     "wof:hierarchy":[
         {
@@ -51,7 +54,7 @@
         }
     ],
     "wof:id":1108758093,
-    "wof:lastmodified":1566609691,
+    "wof:lastmodified":1582360332,
     "wof:name":"Shagra",
     "wof:parent_id":85676759,
     "wof:placetype":"county",

--- a/data/110/875/809/7/1108758097.geojson
+++ b/data/110/875/809/7/1108758097.geojson
@@ -44,6 +44,9 @@
     "wof:concordances":{},
     "wof:country":"QA",
     "wof:created":1481308727,
+    "wof:geom_alt":[
+        "meso"
+    ],
     "wof:geomhash":"88ec548ca27ad65ebe46e8c11f081c24",
     "wof:hierarchy":[
         {
@@ -54,7 +57,7 @@
         }
     ],
     "wof:id":1108758097,
-    "wof:lastmodified":1566609691,
+    "wof:lastmodified":1582360332,
     "wof:name":"Sawda Natheel",
     "wof:parent_id":1377149573,
     "wof:placetype":"county",

--- a/data/110/875/809/9/1108758099.geojson
+++ b/data/110/875/809/9/1108758099.geojson
@@ -41,6 +41,9 @@
     "wof:concordances":{},
     "wof:country":"QA",
     "wof:created":1481308728,
+    "wof:geom_alt":[
+        "meso"
+    ],
     "wof:geomhash":"0ccf271099dd155477045b6ab1a56062",
     "wof:hierarchy":[
         {
@@ -51,7 +54,7 @@
         }
     ],
     "wof:id":1108758099,
-    "wof:lastmodified":1566609691,
+    "wof:lastmodified":1582360332,
     "wof:name":"Al Ebaib/Al Ebb/Al Kheesa/Lusail/Umm Qarn",
     "wof:parent_id":85676781,
     "wof:placetype":"county",

--- a/data/110/875/810/3/1108758103.geojson
+++ b/data/110/875/810/3/1108758103.geojson
@@ -41,6 +41,9 @@
     "wof:concordances":{},
     "wof:country":"QA",
     "wof:created":1481308730,
+    "wof:geom_alt":[
+        "meso"
+    ],
     "wof:geomhash":"cefe0dc7712cdb0f4d1ef7f0bdaed7b3",
     "wof:hierarchy":[
         {
@@ -51,7 +54,7 @@
         }
     ],
     "wof:id":1108758103,
-    "wof:lastmodified":1566609685,
+    "wof:lastmodified":1582360331,
     "wof:name":"Fuwairit/Ain Sinan/Madinat Al Kaaban",
     "wof:parent_id":85676773,
     "wof:placetype":"county",

--- a/data/110/875/810/7/1108758107.geojson
+++ b/data/110/875/810/7/1108758107.geojson
@@ -41,6 +41,9 @@
     "wof:concordances":{},
     "wof:country":"QA",
     "wof:created":1481308731,
+    "wof:geom_alt":[
+        "meso"
+    ],
     "wof:geomhash":"9eb4111878201349ec5ec1920c8b99bc",
     "wof:hierarchy":[
         {
@@ -51,7 +54,7 @@
         }
     ],
     "wof:id":1108758107,
-    "wof:lastmodified":1566609685,
+    "wof:lastmodified":1582360331,
     "wof:name":"Lijmiliya",
     "wof:parent_id":1377149569,
     "wof:placetype":"county",

--- a/data/110/875/810/9/1108758109.geojson
+++ b/data/110/875/810/9/1108758109.geojson
@@ -44,6 +44,9 @@
     "wof:concordances":{},
     "wof:country":"QA",
     "wof:created":1481308732,
+    "wof:geom_alt":[
+        "meso"
+    ],
     "wof:geomhash":"f7d7eae6ef6fb88248ae416ed8c2ca19",
     "wof:hierarchy":[
         {
@@ -54,7 +57,7 @@
         }
     ],
     "wof:id":1108758109,
-    "wof:lastmodified":1566609684,
+    "wof:lastmodified":1582360331,
     "wof:name":"Al Ruwais / Madinat Al Shamal",
     "wof:parent_id":85676773,
     "wof:placetype":"county",

--- a/data/110/875/811/1/1108758111.geojson
+++ b/data/110/875/811/1/1108758111.geojson
@@ -41,6 +41,9 @@
     "wof:concordances":{},
     "wof:country":"QA",
     "wof:created":1481308733,
+    "wof:geom_alt":[
+        "meso"
+    ],
     "wof:geomhash":"203bb7b0fb71613299c14e0864a4ccde",
     "wof:hierarchy":[
         {
@@ -51,7 +54,7 @@
         }
     ],
     "wof:id":1108758111,
-    "wof:lastmodified":1566609684,
+    "wof:lastmodified":1582360331,
     "wof:name":"Al Adaid",
     "wof:parent_id":85676759,
     "wof:placetype":"county",

--- a/data/110/875/812/1/1108758121.geojson
+++ b/data/110/875/812/1/1108758121.geojson
@@ -41,6 +41,9 @@
     "wof:concordances":{},
     "wof:country":"QA",
     "wof:created":1481308739,
+    "wof:geom_alt":[
+        "meso"
+    ],
     "wof:geomhash":"d09889b1867d9fd5070088462804873d",
     "wof:hierarchy":[
         {
@@ -51,7 +54,7 @@
         }
     ],
     "wof:id":1108758121,
-    "wof:lastmodified":1566609689,
+    "wof:lastmodified":1582360332,
     "wof:name":"Al Khor/Al Daayen/Simaisma/Al Jeryan/Al Sunay",
     "wof:parent_id":85676767,
     "wof:placetype":"county",

--- a/data/421/190/363/421190363.geojson
+++ b/data/421/190/363/421190363.geojson
@@ -643,6 +643,9 @@
     ],
     "wof:country":"QA",
     "wof:created":1459009655,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5800acfadc5639d4988594b67e75b50c",
     "wof:hierarchy":[
         {
@@ -654,7 +657,7 @@
         }
     ],
     "wof:id":421190363,
-    "wof:lastmodified":1566609708,
+    "wof:lastmodified":1582360332,
     "wof:name":"Doha",
     "wof:parent_id":1377149699,
     "wof:placetype":"locality",

--- a/data/856/322/99/85632299.geojson
+++ b/data/856/322/99/85632299.geojson
@@ -1011,6 +1011,12 @@
     },
     "wof:country":"QA",
     "wof:country_alpha3":"QAT",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "meso",
+        "naturalearth",
+        "naturalearth-display-terrestrial-zoom6"
+    ],
     "wof:geomhash":"10d42697c8e75b9d67886ae72a90ba4b",
     "wof:hierarchy":[
         {
@@ -1025,7 +1031,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566609673,
+    "wof:lastmodified":1582360329,
     "wof:name":"Qatar",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/767/49/85676749.geojson
+++ b/data/856/767/49/85676749.geojson
@@ -599,6 +599,10 @@
         1377149699
     ],
     "wof:country":"QA",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "meso"
+    ],
     "wof:geomhash":"e5194997cdf00c789c90c2bc2afc7394",
     "wof:hierarchy":[
         {
@@ -614,7 +618,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566609676,
+    "wof:lastmodified":1582360330,
     "wof:name":"Ad Dawhah",
     "wof:parent_id":85632299,
     "wof:placetype":"region",

--- a/data/856/767/55/85676755.geojson
+++ b/data/856/767/55/85676755.geojson
@@ -276,6 +276,10 @@
         "wd:id":"Q311272"
     },
     "wof:country":"QA",
+    "wof:geom_alt":[
+        "meso",
+        "quattroshapes"
+    ],
     "wof:geomhash":"d9df713fc94f111629d73411eb1b0ca5",
     "wof:hierarchy":[
         {
@@ -291,7 +295,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1561830370,
+    "wof:lastmodified":1582360330,
     "wof:name":"Ar Rayy\u0101n",
     "wof:parent_id":85632299,
     "wof:placetype":"region",

--- a/data/856/767/59/85676759.geojson
+++ b/data/856/767/59/85676759.geojson
@@ -241,6 +241,10 @@
         "unlc:id":"QA-WA"
     },
     "wof:country":"QA",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "meso"
+    ],
     "wof:geomhash":"d848d2e75378bf00cbd786750f8b8b34",
     "wof:hierarchy":[
         {
@@ -256,7 +260,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566609674,
+    "wof:lastmodified":1582360329,
     "wof:name":"Al Wakrah",
     "wof:parent_id":85632299,
     "wof:placetype":"region",

--- a/data/856/767/67/85676767.geojson
+++ b/data/856/767/67/85676767.geojson
@@ -280,6 +280,10 @@
         "wd:id":"Q1156471"
     },
     "wof:country":"QA",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "meso"
+    ],
     "wof:geomhash":"59deb83ecbab687a30a27fb4abdad928",
     "wof:hierarchy":[
         {
@@ -295,7 +299,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566609675,
+    "wof:lastmodified":1582360329,
     "wof:name":"Al Khor",
     "wof:parent_id":85632299,
     "wof:placetype":"region",

--- a/data/856/767/73/85676773.geojson
+++ b/data/856/767/73/85676773.geojson
@@ -158,6 +158,10 @@
         "unlc:id":"QA-MS"
     },
     "wof:country":"QA",
+    "wof:geom_alt":[
+        "meso",
+        "quattroshapes"
+    ],
     "wof:geomhash":"7e90f2aa3a1fa47793f2cf81c85e795e",
     "wof:hierarchy":[
         {
@@ -173,7 +177,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566609675,
+    "wof:lastmodified":1582360329,
     "wof:name":"Madinat ach Shamal",
     "wof:parent_id":85632299,
     "wof:placetype":"region",

--- a/data/856/767/77/85676777.geojson
+++ b/data/856/767/77/85676777.geojson
@@ -269,6 +269,10 @@
         "wd:id":"Q990414"
     },
     "wof:country":"QA",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "meso"
+    ],
     "wof:geomhash":"561288b78c67c402dbb948599b1b1ea4",
     "wof:hierarchy":[
         {
@@ -284,7 +288,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566609676,
+    "wof:lastmodified":1582360330,
     "wof:name":"Umm Salal",
     "wof:parent_id":85632299,
     "wof:placetype":"region",

--- a/data/856/767/81/85676781.geojson
+++ b/data/856/767/81/85676781.geojson
@@ -304,6 +304,10 @@
         "wd:id":"Q990414"
     },
     "wof:country":"QA",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "meso"
+    ],
     "wof:geomhash":"4b496b080234008e6a00e278000180fe",
     "wof:hierarchy":[
         {
@@ -319,7 +323,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566609676,
+    "wof:lastmodified":1582360330,
     "wof:name":"Al Daayen",
     "wof:parent_id":85632299,
     "wof:placetype":"region",

--- a/data/859/073/73/85907373.geojson
+++ b/data/859/073/73/85907373.geojson
@@ -77,6 +77,9 @@
         "qs_pg:id":1086008
     },
     "wof:country":"QA",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"49edc0c2c58b03d95faca5a02639de3e",
     "wof:hierarchy":[
         {
@@ -91,7 +94,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566609673,
+    "wof:lastmodified":1582360328,
     "wof:name":"Al Hura",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.