### PR TITLE
Name updates

### DIFF
--- a/data/856/322/99/85632299.geojson
+++ b/data/856/322/99/85632299.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.038818,
-    "geom:area_square_m":11614273950.049374,
+    "geom:area_square_m":11614274402.286535,
     "geom:bbox":"50.750031,24.471111,51.647362,26.184029",
     "geom:latitude":25.284675,
     "geom:longitude":51.192573,
@@ -72,6 +72,9 @@
     ],
     "name:arg_x_preferred":[
         "Qatar"
+    ],
+    "name:ary_x_preferred":[
+        "\u0642\u0637\u0631"
     ],
     "name:arz_x_preferred":[
         "\u0645\u0634\u064a\u062e\u0629 \u0642\u0637\u0631"
@@ -190,6 +193,12 @@
     "name:dan_x_preferred":[
         "Qatar"
     ],
+    "name:deu_at_x_preferred":[
+        "Katar"
+    ],
+    "name:deu_ch_x_preferred":[
+        "Katar"
+    ],
     "name:deu_x_preferred":[
         "Katar"
     ],
@@ -216,6 +225,12 @@
     ],
     "name:ell_x_preferred":[
         "\u039a\u03b1\u03c4\u03ac\u03c1"
+    ],
+    "name:eng_ca_x_preferred":[
+        "Qatar"
+    ],
+    "name:eng_gb_x_preferred":[
+        "Qatar"
     ],
     "name:eng_x_preferred":[
         "Qatar"
@@ -274,6 +289,9 @@
         "Kataar"
     ],
     "name:gag_x_preferred":[
+        "Katar"
+    ],
+    "name:gcr_x_preferred":[
         "Katar"
     ],
     "name:gla_x_preferred":[
@@ -537,6 +555,9 @@
     "name:mon_x_preferred":[
         "\u041a\u0430\u0442\u0430\u0440"
     ],
+    "name:mri_x_preferred":[
+        "Kat\u0101"
+    ],
     "name:msa_x_preferred":[
         "Qatar"
     ],
@@ -639,6 +660,9 @@
     "name:pol_x_preferred":[
         "Katar"
     ],
+    "name:por_br_x_preferred":[
+        "Catar"
+    ],
     "name:por_x_preferred":[
         "Catar"
     ],
@@ -701,6 +725,9 @@
     "name:sme_x_preferred":[
         "Qatar"
     ],
+    "name:smo_x_preferred":[
+        "Qatar"
+    ],
     "name:sna_x_preferred":[
         "Qatar"
     ],
@@ -725,6 +752,15 @@
     "name:sqi_x_variant":[
         "Katar"
     ],
+    "name:srd_x_preferred":[
+        "Qat\u00e0r"
+    ],
+    "name:srp_ec_x_preferred":[
+        "\u041a\u0430\u0442\u0430\u0440"
+    ],
+    "name:srp_el_x_preferred":[
+        "Katar"
+    ],
     "name:srp_x_preferred":[
         "\u041a\u0430\u0442\u0430\u0440"
     ],
@@ -745,6 +781,9 @@
     ],
     "name:szl_x_preferred":[
         "Katar"
+    ],
+    "name:szy_x_preferred":[
+        "Qatar"
     ],
     "name:tam_x_preferred":[
         "\u0b95\u0ba4\u0bcd\u0ba4\u0bbe\u0bb0\u0bcd"
@@ -863,8 +902,17 @@
     "name:zha_x_preferred":[
         "Qatar"
     ],
+    "name:zho_cn_x_preferred":[
+        "\u5361\u5854\u5c14"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u5361\u5854\u723e"
+    ],
     "name:zho_min_nan_x_preferred":[
         "Qatar"
+    ],
+    "name:zho_my_x_preferred":[
+        "\u5361\u5854\u5c14"
     ],
     "name:zho_x_preferred":[
         "\u5361\u5854\u5c14"
@@ -1032,7 +1080,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1583797424,
+    "wof:lastmodified":1587427373,
     "wof:name":"Qatar",
     "wof:parent_id":102191569,
     "wof:placetype":"country",


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1796 and https://github.com/whosonfirst-data/whosonfirst-data/issues/1821.

This PR includes:
- Fixes to property values that start or end with `" "`, `\n`, or `\r`, removing those characters.
- Using a modified version of the [wiki names import script](https://github.com/whosonfirst/whosonfirst-cookbook/blob/master/scripts/crawl_to_add_wiki_names.py), adds new `name` properties

There will be ~260 similar PRs, one for each per-country repo. No PIP work require, can merge as-is.