### PR TITLE
Update non-ascii names, store existing localized names

### DIFF
--- a/data/421/166/869/421166869.geojson
+++ b/data/421/166/869/421166869.geojson
@@ -14,6 +14,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0645\u0646\u0637\u0642\u0629 \u0627\u0644\u0635\u0646\u0627\u0639\u064a\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Industrial Zone "
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":421166869,
-    "wof:lastmodified":1552506365,
-    "wof:name":"\u0627\u0644\u0645\u0646\u0637\u0642\u0629 \u0627\u0644\u0635\u0646\u0627\u0639\u064a\u0629",
+    "wof:lastmodified":1601068392,
+    "wof:name":"Industrial Zone ",
     "wof:parent_id":1377149699,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-qa",

--- a/data/421/166/869/421166869.geojson
+++ b/data/421/166/869/421166869.geojson
@@ -7,7 +7,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"51.4357275,25.192996,51.4357275,25.192996",
+    "geom:bbox":"51.435727,25.192996,51.435727,25.192996",
     "geom:latitude":25.192996,
     "geom:longitude":51.435727,
     "iso:country":"QA",
@@ -18,7 +18,7 @@
         "\u0627\u0644\u0645\u0646\u0637\u0642\u0629 \u0627\u0644\u0635\u0646\u0627\u0639\u064a\u0629"
     ],
     "name:eng_x_preferred":[
-        "Industrial Zone "
+        "Industrial Zone"
     ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
@@ -42,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632299,
-        85676749,
-        1377149699
+        1377149699,
+        85676749
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -52,7 +52,7 @@
     },
     "wof:country":"QA",
     "wof:created":1459008705,
-    "wof:geomhash":"3a22b8037e057d521bc6d8d389b1cca1",
+    "wof:geomhash":"c7de8a372e93401e8702c4caf3cc365e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -63,8 +63,8 @@
         }
     ],
     "wof:id":421166869,
-    "wof:lastmodified":1601068392,
-    "wof:name":"Industrial Zone ",
+    "wof:lastmodified":1601423089,
+    "wof:name":"Industrial Zone",
     "wof:parent_id":1377149699,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-qa",
@@ -75,10 +75,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    51.4357275,
+    51.435727,
     25.192996,
-    51.4357275,
+    51.435727,
     25.192996
 ],
-  "geometry": {"coordinates":[51.4357275,25.192996],"type":"Point"}
+  "geometry": {"coordinates":[51.435727,25.192996],"type":"Point"}
 }

--- a/data/421/170/063/421170063.geojson
+++ b/data/421/170/063/421170063.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0633\u064a\u0644\u064a\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Al Sailiya"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421170063,
-    "wof:lastmodified":1566609709,
-    "wof:name":"\u0627\u0644\u0633\u064a\u0644\u064a\u0629",
+    "wof:lastmodified":1601068391,
+    "wof:name":"Al Sailiya",
     "wof:parent_id":1108758067,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-qa",

--- a/data/421/170/063/421170063.geojson
+++ b/data/421/170/063/421170063.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632299,
-        1377149573,
-        1108758067
+        1108758067,
+        1377149573
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421170063,
-    "wof:lastmodified":1601068391,
+    "wof:lastmodified":1601423085,
     "wof:name":"Al Sailiya",
     "wof:parent_id":1108758067,
     "wof:placetype":"locality",

--- a/data/421/170/065/421170065.geojson
+++ b/data/421/170/065/421170065.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0631\u0648\u0636\u0629 \u0631\u0627\u0634\u062f"
+    ],
+    "name:eng_x_preferred":[
+        "Rawdat Rashed"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421170065,
-    "wof:lastmodified":1566609709,
-    "wof:name":"\u0631\u0648\u0636\u0629 \u0631\u0627\u0634\u062f",
+    "wof:lastmodified":1601068396,
+    "wof:name":"Rawdat Rashed",
     "wof:parent_id":1108758117,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-qa",

--- a/data/421/170/065/421170065.geojson
+++ b/data/421/170/065/421170065.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632299,
-        1377149569,
-        1108758117
+        1108758117,
+        1377149569
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421170065,
-    "wof:lastmodified":1601068396,
+    "wof:lastmodified":1601423091,
     "wof:name":"Rawdat Rashed",
     "wof:parent_id":1108758117,
     "wof:placetype":"locality",

--- a/data/421/171/385/421171385.geojson
+++ b/data/421/171/385/421171385.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632299,
-        85676773,
-        1108757947
+        1108757947,
+        85676773
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421171385,
-    "wof:lastmodified":1601068390,
+    "wof:lastmodified":1601423086,
     "wof:name":"Al Zubara",
     "wof:parent_id":1108757947,
     "wof:placetype":"locality",

--- a/data/421/171/385/421171385.geojson
+++ b/data/421/171/385/421171385.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0632\u0628\u0627\u0631\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Al Zubara"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421171385,
-    "wof:lastmodified":1566609709,
-    "wof:name":"\u0627\u0644\u0632\u0628\u0627\u0631\u0629",
+    "wof:lastmodified":1601068390,
+    "wof:name":"Al Zubara",
     "wof:parent_id":1108757947,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-qa",

--- a/data/421/172/069/421172069.geojson
+++ b/data/421/172/069/421172069.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632299,
-        85676759,
-        1108757955
+        1108757955,
+        85676759
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421172069,
-    "wof:lastmodified":1601068400,
+    "wof:lastmodified":1601423090,
     "wof:name":"Mesaieed Industrial Area",
     "wof:parent_id":1108757955,
     "wof:placetype":"locality",

--- a/data/421/172/069/421172069.geojson
+++ b/data/421/172/069/421172069.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0645\u0646\u0637\u0642\u0629 \u0645\u0633\u064a\u0639\u064a\u062f \u0627\u0644\u0635\u0646\u0627\u0639\u064a\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Mesaieed Industrial Area"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421172069,
-    "wof:lastmodified":1566609706,
-    "wof:name":"\u0645\u0646\u0637\u0642\u0629 \u0645\u0633\u064a\u0639\u064a\u062f \u0627\u0644\u0635\u0646\u0627\u0639\u064a\u0629",
+    "wof:lastmodified":1601068400,
+    "wof:name":"Mesaieed Industrial Area",
     "wof:parent_id":1108757955,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-qa",

--- a/data/421/172/071/421172071.geojson
+++ b/data/421/172/071/421172071.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0645 \u0635\u0644\u0627\u0644"
+    ],
+    "name:eng_x_preferred":[
+        "Umm Salal"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421172071,
-    "wof:lastmodified":1566609706,
-    "wof:name":"\u0627\u0645 \u0635\u0644\u0627\u0644",
+    "wof:lastmodified":1601068393,
+    "wof:name":"Umm Salal",
     "wof:parent_id":1108758101,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-qa",

--- a/data/421/172/071/421172071.geojson
+++ b/data/421/172/071/421172071.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632299,
-        85676777,
-        1108758101
+        1108758101,
+        85676777
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421172071,
-    "wof:lastmodified":1601068393,
+    "wof:lastmodified":1601423094,
     "wof:name":"Umm Salal",
     "wof:parent_id":1108758101,
     "wof:placetype":"locality",

--- a/data/421/172/077/421172077.geojson
+++ b/data/421/172/077/421172077.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0633\u064a\u0644\u064a\u0629 \u062c\u0646\u0648\u0628"
+    ],
+    "name:eng_x_preferred":[
+        "Al Sailiya South"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421172077,
-    "wof:lastmodified":1566609706,
-    "wof:name":"\u0627\u0644\u0633\u064a\u0644\u064a\u0629 \u062c\u0646\u0648\u0628",
+    "wof:lastmodified":1601068391,
+    "wof:name":"Al Sailiya South",
     "wof:parent_id":1108758085,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-qa",

--- a/data/421/172/077/421172077.geojson
+++ b/data/421/172/077/421172077.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632299,
-        1377149573,
-        1108758085
+        1108758085,
+        1377149573
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421172077,
-    "wof:lastmodified":1601068391,
+    "wof:lastmodified":1601423085,
     "wof:name":"Al Sailiya South",
     "wof:parent_id":1108758085,
     "wof:placetype":"locality",

--- a/data/421/176/833/421176833.geojson
+++ b/data/421/176/833/421176833.geojson
@@ -14,6 +14,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u063a\u0631\u0627\u0641\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Al Gharafa"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":421176833,
-    "wof:lastmodified":1552506366,
-    "wof:name":"\u0627\u0644\u063a\u0631\u0627\u0641\u0629",
+    "wof:lastmodified":1601068391,
+    "wof:name":"Al Gharafa",
     "wof:parent_id":1377149699,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-qa",

--- a/data/421/176/833/421176833.geojson
+++ b/data/421/176/833/421176833.geojson
@@ -42,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632299,
-        85676749,
-        1377149699
+        1377149699,
+        85676749
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -63,7 +63,7 @@
         }
     ],
     "wof:id":421176833,
-    "wof:lastmodified":1601068391,
+    "wof:lastmodified":1601423084,
     "wof:name":"Al Gharafa",
     "wof:parent_id":1377149699,
     "wof:placetype":"locality",

--- a/data/421/178/341/421178341.geojson
+++ b/data/421/178/341/421178341.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632299,
-        85676773,
-        1108757947
+        1108757947,
+        85676773
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421178341,
-    "wof:lastmodified":1601068389,
+    "wof:lastmodified":1601423084,
     "wof:name":"Al Jafara",
     "wof:parent_id":1108757947,
     "wof:placetype":"locality",

--- a/data/421/178/341/421178341.geojson
+++ b/data/421/178/341/421178341.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u062c\u0641\u0627\u0631\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Al Jafara"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421178341,
-    "wof:lastmodified":1566609709,
-    "wof:name":"\u0627\u0644\u062c\u0641\u0627\u0631\u0629",
+    "wof:lastmodified":1601068389,
+    "wof:name":"Al Jafara",
     "wof:parent_id":1108757947,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-qa",

--- a/data/421/179/415/421179415.geojson
+++ b/data/421/179/415/421179415.geojson
@@ -14,6 +14,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u062e\u064a\u0633\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Al Kheesa"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -57,8 +63,8 @@
         }
     ],
     "wof:id":421179415,
-    "wof:lastmodified":1552506367,
-    "wof:name":"\u0627\u0644\u062e\u064a\u0633\u0629",
+    "wof:lastmodified":1601068390,
+    "wof:name":"Al Kheesa",
     "wof:parent_id":1377149699,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-qa",

--- a/data/421/179/415/421179415.geojson
+++ b/data/421/179/415/421179415.geojson
@@ -42,8 +42,8 @@
     "wof:belongsto":[
         102191569,
         85632299,
-        85676749,
-        1377149699
+        1377149699,
+        85676749
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -63,7 +63,7 @@
         }
     ],
     "wof:id":421179415,
-    "wof:lastmodified":1601068390,
+    "wof:lastmodified":1601423084,
     "wof:name":"Al Kheesa",
     "wof:parent_id":1377149699,
     "wof:placetype":"locality",

--- a/data/421/181/727/421181727.geojson
+++ b/data/421/181/727/421181727.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0634\u062d\u0627\u0646\u064a\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Al Shahania"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421181727,
-    "wof:lastmodified":1566609707,
-    "wof:name":"\u0627\u0644\u0634\u062d\u0627\u0646\u064a\u0629",
+    "wof:lastmodified":1601068391,
+    "wof:name":"Al Shahania",
     "wof:parent_id":1108758115,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-qa",

--- a/data/421/181/727/421181727.geojson
+++ b/data/421/181/727/421181727.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632299,
-        1377149569,
-        1108758115
+        1108758115,
+        1377149569
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421181727,
-    "wof:lastmodified":1601068391,
+    "wof:lastmodified":1601423086,
     "wof:name":"Al Shahania",
     "wof:parent_id":1108758115,
     "wof:placetype":"locality",

--- a/data/421/183/893/421183893.geojson
+++ b/data/421/183/893/421183893.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0645 \u0627\u0644\u0627\u0641\u0627\u0639\u064a"
+    ],
+    "name:eng_x_preferred":[
+        "Umm Al Afaei"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421183893,
-    "wof:lastmodified":1566609709,
-    "wof:name":"\u0627\u0645 \u0627\u0644\u0627\u0641\u0627\u0639\u064a",
+    "wof:lastmodified":1601068393,
+    "wof:name":"Umm Al Afaei",
     "wof:parent_id":1108758057,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-qa",

--- a/data/421/183/893/421183893.geojson
+++ b/data/421/183/893/421183893.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632299,
-        1377149573,
-        1108758057
+        1108758057,
+        1377149573
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421183893,
-    "wof:lastmodified":1601068393,
+    "wof:lastmodified":1601423094,
     "wof:name":"Umm Al Afaei",
     "wof:parent_id":1108758057,
     "wof:placetype":"locality",

--- a/data/421/183/955/421183955.geojson
+++ b/data/421/183/955/421183955.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"51.4124105,25.0506905,51.4124105,25.0506905",
+    "geom:bbox":"51.412411,25.050691,51.412411,25.050691",
     "geom:latitude":25.050691,
     "geom:longitude":51.412411,
     "iso:country":"QA",
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632299,
-        85676759,
-        1108758095
+        1108758095,
+        85676759
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -55,7 +55,7 @@
     },
     "wof:country":"QA",
     "wof:created":1459009396,
-    "wof:geomhash":"2e09fd181f8705023aafa46d4be34950",
+    "wof:geomhash":"ef6855a79fc3381e2c123c2b264010fa",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421183955,
-    "wof:lastmodified":1601068389,
+    "wof:lastmodified":1601423084,
     "wof:name":"Al Kharrara",
     "wof:parent_id":1108758095,
     "wof:placetype":"locality",
@@ -76,10 +76,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    51.4124105,
-    25.0506905,
-    51.4124105,
-    25.0506905
+    51.412411,
+    25.050691,
+    51.412411,
+    25.050691
 ],
-  "geometry": {"coordinates":[51.4124105,25.0506905],"type":"Point"}
+  "geometry": {"coordinates":[51.412411,25.050691],"type":"Point"}
 }

--- a/data/421/183/955/421183955.geojson
+++ b/data/421/183/955/421183955.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u062e\u0631\u0627\u0631\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Al Kharrara"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421183955,
-    "wof:lastmodified":1566609709,
-    "wof:name":"\u0627\u0644\u062e\u0631\u0627\u0631\u0629",
+    "wof:lastmodified":1601068389,
+    "wof:name":"Al Kharrara",
     "wof:parent_id":1108758095,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-qa",

--- a/data/421/184/213/421184213.geojson
+++ b/data/421/184/213/421184213.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"51.0354525,24.8821795,51.0354525,24.8821795",
+    "geom:bbox":"51.035452,24.882179,51.035452,24.882179",
     "geom:latitude":24.882179,
     "geom:longitude":51.035452,
     "iso:country":"QA",
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632299,
-        1377149573,
-        1108757959
+        1108757959,
+        1377149573
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -55,7 +55,7 @@
     },
     "wof:country":"QA",
     "wof:created":1459009403,
-    "wof:geomhash":"8534493c5b87238c42aae617ba9d3a3e",
+    "wof:geomhash":"84257b34a211b009eb731b7e8f7f92ff",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421184213,
-    "wof:lastmodified":1601068393,
+    "wof:lastmodified":1601423094,
     "wof:name":"Umm Hawta",
     "wof:parent_id":1108757959,
     "wof:placetype":"locality",
@@ -76,10 +76,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    51.0354525,
-    24.8821795,
-    51.0354525,
-    24.8821795
+    51.035452,
+    24.882179,
+    51.035452,
+    24.882179
 ],
-  "geometry": {"coordinates":[51.0354525,24.8821795],"type":"Point"}
+  "geometry": {"coordinates":[51.035452,24.882179],"type":"Point"}
 }

--- a/data/421/184/213/421184213.geojson
+++ b/data/421/184/213/421184213.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0645 \u062d\u0648\u0637\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Umm Hawta"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421184213,
-    "wof:lastmodified":1566609709,
-    "wof:name":"\u0627\u0645 \u062d\u0648\u0637\u0629",
+    "wof:lastmodified":1601068393,
+    "wof:name":"Umm Hawta",
     "wof:parent_id":1108757959,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-qa",

--- a/data/421/184/433/421184433.geojson
+++ b/data/421/184/433/421184433.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632299,
-        85676781,
-        1108758099
+        1108758099,
+        85676781
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421184433,
-    "wof:lastmodified":1601068397,
+    "wof:lastmodified":1601423092,
     "wof:name":"Simaisma",
     "wof:parent_id":1108758099,
     "wof:placetype":"locality",

--- a/data/421/184/433/421184433.geojson
+++ b/data/421/184/433/421184433.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0633\u0645\u064a\u0633\u0645\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Simaisma"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421184433,
-    "wof:lastmodified":1566609709,
-    "wof:name":"\u0633\u0645\u064a\u0633\u0645\u0629",
+    "wof:lastmodified":1601068397,
+    "wof:name":"Simaisma",
     "wof:parent_id":1108758099,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-qa",

--- a/data/421/184/513/421184513.geojson
+++ b/data/421/184/513/421184513.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u062d\u0648\u064a\u0644\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Al Huwaila"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421184513,
-    "wof:lastmodified":1566609709,
-    "wof:name":"\u0627\u0644\u062d\u0648\u064a\u0644\u0629",
+    "wof:lastmodified":1601068389,
+    "wof:name":"Al Huwaila",
     "wof:parent_id":1108757945,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-qa",

--- a/data/421/184/513/421184513.geojson
+++ b/data/421/184/513/421184513.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632299,
-        85676767,
-        1108757945
+        1108757945,
+        85676767
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421184513,
-    "wof:lastmodified":1601068389,
+    "wof:lastmodified":1601423084,
     "wof:name":"Al Huwaila",
     "wof:parent_id":1108757945,
     "wof:placetype":"locality",

--- a/data/421/185/383/421185383.geojson
+++ b/data/421/185/383/421185383.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632299,
-        1377149569,
-        1108757941
+        1108757941,
+        1377149569
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421185383,
-    "wof:lastmodified":1601068397,
+    "wof:lastmodified":1601423094,
     "wof:name":"Zikreet",
     "wof:parent_id":1108757941,
     "wof:placetype":"locality",

--- a/data/421/185/383/421185383.geojson
+++ b/data/421/185/383/421185383.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0632\u064a\u0643\u0631\u064a\u062a"
+    ],
+    "name:eng_x_preferred":[
+        "Zikreet"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421185383,
-    "wof:lastmodified":1566609709,
-    "wof:name":"\u0632\u064a\u0643\u0631\u064a\u062a",
+    "wof:lastmodified":1601068397,
+    "wof:name":"Zikreet",
     "wof:parent_id":1108757941,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-qa",

--- a/data/421/185/691/421185691.geojson
+++ b/data/421/185/691/421185691.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632299,
-        85676773,
-        1108758109
+        1108758109,
+        85676773
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421185691,
-    "wof:lastmodified":1601068390,
+    "wof:lastmodified":1601423085,
     "wof:name":"Al Ruwais",
     "wof:parent_id":1108758109,
     "wof:placetype":"locality",

--- a/data/421/185/691/421185691.geojson
+++ b/data/421/185/691/421185691.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0631\u0648\u064a\u0633"
+    ],
+    "name:eng_x_preferred":[
+        "Al Ruwais"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421185691,
-    "wof:lastmodified":1566609709,
-    "wof:name":"\u0627\u0644\u0631\u0648\u064a\u0633",
+    "wof:lastmodified":1601068390,
+    "wof:name":"Al Ruwais",
     "wof:parent_id":1108758109,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-qa",

--- a/data/421/186/399/421186399.geojson
+++ b/data/421/186/399/421186399.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0648\u0633\u064a\u0644"
+    ],
+    "name:eng_x_preferred":[
+        "Al Waseel"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421186399,
-    "wof:lastmodified":1566609706,
-    "wof:name":"\u0627\u0644\u0648\u0633\u064a\u0644",
+    "wof:lastmodified":1601068393,
+    "wof:name":"Al Waseel",
     "wof:parent_id":1108758099,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-qa",

--- a/data/421/186/399/421186399.geojson
+++ b/data/421/186/399/421186399.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632299,
-        85676781,
-        1108758099
+        1108758099,
+        85676781
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421186399,
-    "wof:lastmodified":1601068393,
+    "wof:lastmodified":1601423086,
     "wof:name":"Al Waseel",
     "wof:parent_id":1108758099,
     "wof:placetype":"locality",

--- a/data/421/186/453/421186453.geojson
+++ b/data/421/186/453/421186453.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632299,
-        1377149573,
-        1108757959
+        1108757959,
+        1377149573
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421186453,
-    "wof:lastmodified":1601068397,
+    "wof:lastmodified":1601423092,
     "wof:name":"Sawda Natheel",
     "wof:parent_id":1108757959,
     "wof:placetype":"locality",

--- a/data/421/186/453/421186453.geojson
+++ b/data/421/186/453/421186453.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0633\u0648\u062f\u0629 \u0646\u0630\u064a\u0644"
+    ],
+    "name:eng_x_preferred":[
+        "Sawda Natheel"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421186453,
-    "wof:lastmodified":1566609707,
-    "wof:name":"\u0633\u0648\u062f\u0629 \u0646\u0630\u064a\u0644",
+    "wof:lastmodified":1601068397,
+    "wof:name":"Sawda Natheel",
     "wof:parent_id":1108757959,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-qa",

--- a/data/421/186/517/421186517.geojson
+++ b/data/421/186/517/421186517.geojson
@@ -10,6 +10,12 @@
     "geom:latitude":25.898761,
     "geom:longitude":51.558151,
     "iso:country":"QA",
+    "label:eng_x_preferred_longname":[
+        "Ras Laffan Industrial City"
+    ],
+    "label:eng_x_preferred_placetype":[
+        "city"
+    ],
     "lbl:bbox":"51.538151,25.878761,51.578151,25.918761",
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
@@ -21,6 +27,9 @@
         "\u0645\u062f\u064a\u0646\u0629 \u0631\u0627\u0633 \u0644\u0641\u0627\u0646 \u0627\u0644\u0635\u0646\u0627\u0639\u064a\u0629"
     ],
     "name:eng_x_preferred":[
+        "Ras Laffan Industrial"
+    ],
+    "name:eng_x_variant":[
         "Ras Laffan Industrial City"
     ],
     "qs:gn_country":null,
@@ -66,8 +75,8 @@
         }
     ],
     "wof:id":421186517,
-    "wof:lastmodified":1601068400,
-    "wof:name":"Ras Laffan Industrial City",
+    "wof:lastmodified":1601337573,
+    "wof:name":"Ras Laffan Industrial",
     "wof:parent_id":1108757945,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-qa",

--- a/data/421/186/517/421186517.geojson
+++ b/data/421/186/517/421186517.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0645\u062f\u064a\u0646\u0629 \u0631\u0627\u0633 \u0644\u0641\u0627\u0646 \u0627\u0644\u0635\u0646\u0627\u0639\u064a\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Ras Laffan Industrial City"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421186517,
-    "wof:lastmodified":1566609707,
-    "wof:name":"\u0645\u062f\u064a\u0646\u0629 \u0631\u0627\u0633 \u0644\u0641\u0627\u0646 \u0627\u0644\u0635\u0646\u0627\u0639\u064a\u0629",
+    "wof:lastmodified":1601068400,
+    "wof:name":"Ras Laffan Industrial City",
     "wof:parent_id":1108757945,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-qa",

--- a/data/421/186/517/421186517.geojson
+++ b/data/421/186/517/421186517.geojson
@@ -10,12 +10,6 @@
     "geom:latitude":25.898761,
     "geom:longitude":51.558151,
     "iso:country":"QA",
-    "label:eng_x_preferred_longname":[
-        "Ras Laffan Industrial City"
-    ],
-    "label:eng_x_preferred_placetype":[
-        "city"
-    ],
     "lbl:bbox":"51.538151,25.878761,51.578151,25.918761",
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
@@ -27,9 +21,6 @@
         "\u0645\u062f\u064a\u0646\u0629 \u0631\u0627\u0633 \u0644\u0641\u0627\u0646 \u0627\u0644\u0635\u0646\u0627\u0639\u064a\u0629"
     ],
     "name:eng_x_preferred":[
-        "Ras Laffan Industrial"
-    ],
-    "name:eng_x_variant":[
         "Ras Laffan Industrial City"
     ],
     "qs:gn_country":null,
@@ -54,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632299,
-        85676767,
-        1108757945
+        1108757945,
+        85676767
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -75,8 +66,8 @@
         }
     ],
     "wof:id":421186517,
-    "wof:lastmodified":1601337573,
-    "wof:name":"Ras Laffan Industrial",
+    "wof:lastmodified":1601423091,
+    "wof:name":"Ras Laffan Industrial City",
     "wof:parent_id":1108757945,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-qa",

--- a/data/421/188/791/421188791.geojson
+++ b/data/421/188/791/421188791.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u062c\u0645\u064a\u0644\u064a\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Al Jameliah"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421188791,
-    "wof:lastmodified":1566609706,
-    "wof:name":"\u0627\u0644\u062c\u0645\u064a\u0644\u064a\u0629",
+    "wof:lastmodified":1601068389,
+    "wof:name":"Al Jameliah",
     "wof:parent_id":1108758107,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-qa",

--- a/data/421/188/791/421188791.geojson
+++ b/data/421/188/791/421188791.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632299,
-        1377149569,
-        1108758107
+        1108758107,
+        1377149569
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421188791,
-    "wof:lastmodified":1601068389,
+    "wof:lastmodified":1601423084,
     "wof:name":"Al Jameliah",
     "wof:parent_id":1108758107,
     "wof:placetype":"locality",

--- a/data/421/190/355/421190355.geojson
+++ b/data/421/190/355/421190355.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0628\u0648 \u0636\u0644\u0648\u0641"
+    ],
+    "name:eng_x_preferred":[
+        "Abu Dhalouf"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421190355,
-    "wof:lastmodified":1566609708,
-    "wof:name":"\u0627\u0628\u0648 \u0636\u0644\u0648\u0641",
+    "wof:lastmodified":1601068388,
+    "wof:name":"Abu Dhalouf",
     "wof:parent_id":1108757947,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-qa",

--- a/data/421/190/355/421190355.geojson
+++ b/data/421/190/355/421190355.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632299,
-        85676773,
-        1108757947
+        1108757947,
+        85676773
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421190355,
-    "wof:lastmodified":1601068388,
+    "wof:lastmodified":1601423082,
     "wof:name":"Abu Dhalouf",
     "wof:parent_id":1108757947,
     "wof:placetype":"locality",

--- a/data/421/190/357/421190357.geojson
+++ b/data/421/190/357/421190357.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632299,
-        85676773,
-        1108757947
+        1108757947,
+        85676773
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421190357,
-    "wof:lastmodified":1601068391,
+    "wof:lastmodified":1601423083,
     "wof:name":"Al Arish",
     "wof:parent_id":1108757947,
     "wof:placetype":"locality",

--- a/data/421/190/357/421190357.geojson
+++ b/data/421/190/357/421190357.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0639\u0631\u064a\u0634"
+    ],
+    "name:eng_x_preferred":[
+        "Al Arish"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421190357,
-    "wof:lastmodified":1566609708,
-    "wof:name":"\u0627\u0644\u0639\u0631\u064a\u0634",
+    "wof:lastmodified":1601068391,
+    "wof:name":"Al Arish",
     "wof:parent_id":1108757947,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-qa",

--- a/data/421/190/359/421190359.geojson
+++ b/data/421/190/359/421190359.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u062f\u062e\u064a\u0631\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Al Dakhira"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421190359,
-    "wof:lastmodified":1566609708,
-    "wof:name":"\u0627\u0644\u062f\u062e\u064a\u0631\u0629",
+    "wof:lastmodified":1601068390,
+    "wof:name":"Al Dakhira",
     "wof:parent_id":1108758121,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-qa",

--- a/data/421/190/359/421190359.geojson
+++ b/data/421/190/359/421190359.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632299,
-        85676767,
-        1108758121
+        1108758121,
+        85676767
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421190359,
-    "wof:lastmodified":1601068390,
+    "wof:lastmodified":1601423083,
     "wof:name":"Al Dakhira",
     "wof:parent_id":1108758121,
     "wof:placetype":"locality",

--- a/data/421/190/365/421190365.geojson
+++ b/data/421/190/365/421190365.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632299,
-        85676773,
-        1108758109
+        1108758109,
+        85676773
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421190365,
-    "wof:lastmodified":1601068391,
+    "wof:lastmodified":1601423084,
     "wof:name":"Al Ghariyah",
     "wof:parent_id":1108758109,
     "wof:placetype":"locality",

--- a/data/421/190/365/421190365.geojson
+++ b/data/421/190/365/421190365.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u063a\u0627\u0631\u064a\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Al Ghariyah"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421190365,
-    "wof:lastmodified":1566609707,
-    "wof:name":"\u0627\u0644\u063a\u0627\u0631\u064a\u0629",
+    "wof:lastmodified":1601068391,
+    "wof:name":"Al Ghariyah",
     "wof:parent_id":1108758109,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-qa",

--- a/data/421/194/691/421194691.geojson
+++ b/data/421/194/691/421194691.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0645 \u0635\u0644\u0627\u0644 \u0645\u062d\u0645\u062f"
+    ],
+    "name:eng_x_preferred":[
+        "Umm Salal Mohammed"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421194691,
-    "wof:lastmodified":1566609705,
-    "wof:name":"\u0627\u0645 \u0635\u0644\u0627\u0644 \u0645\u062d\u0645\u062f",
+    "wof:lastmodified":1601068393,
+    "wof:name":"Umm Salal Mohammed",
     "wof:parent_id":1108758101,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-qa",

--- a/data/421/194/691/421194691.geojson
+++ b/data/421/194/691/421194691.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632299,
-        85676777,
-        1108758101
+        1108758101,
+        85676777
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421194691,
-    "wof:lastmodified":1601068393,
+    "wof:lastmodified":1601423094,
     "wof:name":"Umm Salal Mohammed",
     "wof:parent_id":1108758101,
     "wof:placetype":"locality",

--- a/data/421/194/871/421194871.geojson
+++ b/data/421/194/871/421194871.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0645 \u0642\u0631\u0646"
+    ],
+    "name:eng_x_preferred":[
+        "Umm Qarn"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421194871,
-    "wof:lastmodified":1566609705,
-    "wof:name":"\u0627\u0645 \u0642\u0631\u0646",
+    "wof:lastmodified":1601068393,
+    "wof:name":"Umm Qarn",
     "wof:parent_id":1108758099,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-qa",

--- a/data/421/194/871/421194871.geojson
+++ b/data/421/194/871/421194871.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632299,
-        85676781,
-        1108758099
+        1108758099,
+        85676781
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421194871,
-    "wof:lastmodified":1601068393,
+    "wof:lastmodified":1601423094,
     "wof:name":"Umm Qarn",
     "wof:parent_id":1108758099,
     "wof:placetype":"locality",

--- a/data/421/200/111/421200111.geojson
+++ b/data/421/200/111/421200111.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"51.442065,25.2585085,51.442065,25.2585085",
+    "geom:bbox":"51.442065,25.258509,51.442065,25.258509",
     "geom:latitude":25.258509,
     "geom:longitude":51.442065,
     "iso:country":"QA",
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632299,
-        1377149573,
-        1108758065
+        1108758065,
+        1377149573
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -55,7 +55,7 @@
     },
     "wof:country":"QA",
     "wof:created":1459010011,
-    "wof:geomhash":"f4f0b7630a6dd56265b5a4b648dab0cd",
+    "wof:geomhash":"b6d6fa04007a770e0ef6747e0b12d55f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421200111,
-    "wof:lastmodified":1601068390,
+    "wof:lastmodified":1601423092,
     "wof:name":"Sudan",
     "wof:parent_id":1108758065,
     "wof:placetype":"locality",
@@ -77,9 +77,9 @@
 },
   "bbox": [
     51.442065,
-    25.2585085,
+    25.258509,
     51.442065,
-    25.2585085
+    25.258509
 ],
-  "geometry": {"coordinates":[51.442065,25.2585085],"type":"Point"}
+  "geometry": {"coordinates":[51.442065,25.258509],"type":"Point"}
 }

--- a/data/421/200/111/421200111.geojson
+++ b/data/421/200/111/421200111.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0633\u0648\u062f\u0627\u0646"
+    ],
+    "name:eng_x_preferred":[
+        "Sudan"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421200111,
-    "wof:lastmodified":1566609708,
-    "wof:name":"\u0627\u0644\u0633\u0648\u062f\u0627\u0646",
+    "wof:lastmodified":1601068390,
+    "wof:name":"Sudan",
     "wof:parent_id":1108758065,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-qa",

--- a/data/421/200/751/421200751.geojson
+++ b/data/421/200/751/421200751.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0641\u0648\u064a\u0631\u0637"
+    ],
+    "name:eng_x_preferred":[
+        "Fuwayrit"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421200751,
-    "wof:lastmodified":1566609709,
-    "wof:name":"\u0641\u0648\u064a\u0631\u0637",
+    "wof:lastmodified":1601068399,
+    "wof:name":"Fuwayrit",
     "wof:parent_id":1108758103,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-qa",

--- a/data/421/200/751/421200751.geojson
+++ b/data/421/200/751/421200751.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"51.3704125,26.027555,51.3704125,26.027555",
+    "geom:bbox":"51.370413,26.027555,51.370413,26.027555",
     "geom:latitude":26.027555,
     "geom:longitude":51.370413,
     "iso:country":"QA",
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632299,
-        85676773,
-        1108758103
+        1108758103,
+        85676773
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -55,7 +55,7 @@
     },
     "wof:country":"QA",
     "wof:created":1459010037,
-    "wof:geomhash":"5e5b0ef0ecd42bf1335f3f660a1d39ab",
+    "wof:geomhash":"0b6217dad7d565074b2dd0bdd6005a13",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421200751,
-    "wof:lastmodified":1601068399,
+    "wof:lastmodified":1601423089,
     "wof:name":"Fuwayrit",
     "wof:parent_id":1108758103,
     "wof:placetype":"locality",
@@ -76,10 +76,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    51.3704125,
+    51.370413,
     26.027555,
-    51.3704125,
+    51.370413,
     26.027555
 ],
-  "geometry": {"coordinates":[51.3704125,26.027555],"type":"Point"}
+  "geometry": {"coordinates":[51.370413,26.027555],"type":"Point"}
 }

--- a/data/421/200/753/421200753.geojson
+++ b/data/421/200/753/421200753.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632299,
-        85676759,
-        1108757955
+        1108757955,
+        85676759
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421200753,
-    "wof:lastmodified":1601068400,
+    "wof:lastmodified":1601423090,
     "wof:name":"Mesaieed",
     "wof:parent_id":1108757955,
     "wof:placetype":"locality",

--- a/data/421/200/753/421200753.geojson
+++ b/data/421/200/753/421200753.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0645\u0633\u064a\u0639\u064a\u062f"
+    ],
+    "name:eng_x_preferred":[
+        "Mesaieed"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421200753,
-    "wof:lastmodified":1566609708,
-    "wof:name":"\u0645\u0633\u064a\u0639\u064a\u062f",
+    "wof:lastmodified":1601068400,
+    "wof:name":"Mesaieed",
     "wof:parent_id":1108757955,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-qa",

--- a/data/421/203/279/421203279.geojson
+++ b/data/421/203/279/421203279.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0631\u064a\u0627\u0646 \u0627\u0644\u062c\u062f\u064a\u062f"
+    ],
+    "name:eng_x_preferred":[
+        "Al Rayyan Al Jadeed"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421203279,
-    "wof:lastmodified":1566609705,
-    "wof:name":"\u0627\u0644\u0631\u064a\u0627\u0646 \u0627\u0644\u062c\u062f\u064a\u062f",
+    "wof:lastmodified":1601068390,
+    "wof:name":"Al Rayyan Al Jadeed",
     "wof:parent_id":1108758063,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-qa",

--- a/data/421/203/279/421203279.geojson
+++ b/data/421/203/279/421203279.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632299,
-        1377149573,
-        1108758063
+        1108758063,
+        1377149573
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421203279,
-    "wof:lastmodified":1601068390,
+    "wof:lastmodified":1601423085,
     "wof:name":"Al Rayyan Al Jadeed",
     "wof:parent_id":1108758063,
     "wof:placetype":"locality",

--- a/data/421/203/603/421203603.geojson
+++ b/data/421/203/603/421203603.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u062e\u0628\u064a\u0628"
+    ],
+    "name:eng_x_preferred":[
+        "Al Khubayb"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421203603,
-    "wof:lastmodified":1566609705,
-    "wof:name":"\u0627\u0644\u062e\u0628\u064a\u0628",
+    "wof:lastmodified":1601068389,
+    "wof:name":"Al Khubayb",
     "wof:parent_id":1108758115,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-qa",

--- a/data/421/203/603/421203603.geojson
+++ b/data/421/203/603/421203603.geojson
@@ -45,8 +45,8 @@
     "wof:belongsto":[
         102191569,
         85632299,
-        1377149569,
-        1108758115
+        1108758115,
+        1377149569
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421203603,
-    "wof:lastmodified":1601068389,
+    "wof:lastmodified":1601423084,
     "wof:name":"Al Khubayb",
     "wof:parent_id":1108758115,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/183.

This PR updates loclized `wof:name` values in records that currently have no `name:eng_x_*` properties. There are other records that will need to be updated as part of this work too, but those will be handled in a separate PR.

The existing `wof:name` should be stored in the appropriate `name:*` property, with `wof:name` and `name:eng_x_preferred` properties getting updated English name values.

No PIP work needed, these are just property updates.