### PR TITLE
qa concordances, placetype local, and more

### DIFF
--- a/data/110/875/794/1/1108757941.geojson
+++ b/data/110/875/794/1/1108757941.geojson
@@ -56,7 +56,10 @@
         1377149569
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"72"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"QA",
     "wof:created":1481308637,
     "wof:geom_alt":[
@@ -72,7 +75,7 @@
         }
     ],
     "wof:id":1108757941,
-    "wof:lastmodified":1694498070,
+    "wof:lastmodified":1695886248,
     "wof:name":"Al Utouriya",
     "wof:parent_id":1377149569,
     "wof:placetype":"county",

--- a/data/110/875/794/5/1108757945.geojson
+++ b/data/110/875/794/5/1108757945.geojson
@@ -50,7 +50,10 @@
         85676767
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"75"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"QA",
     "wof:created":1481308638,
     "wof:geom_alt":[
@@ -66,7 +69,7 @@
         }
     ],
     "wof:id":1108757945,
-    "wof:lastmodified":1694498070,
+    "wof:lastmodified":1695886248,
     "wof:name":"Al Thakhira/Rass Laffan/Umm Birka",
     "wof:parent_id":85676767,
     "wof:placetype":"county",

--- a/data/110/875/794/7/1108757947.geojson
+++ b/data/110/875/794/7/1108757947.geojson
@@ -50,7 +50,10 @@
         85676773
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"78"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"QA",
     "wof:created":1481308640,
     "wof:geom_alt":[
@@ -66,7 +69,7 @@
         }
     ],
     "wof:id":1108757947,
-    "wof:lastmodified":1694498069,
+    "wof:lastmodified":1695886246,
     "wof:name":"Abu Dhalouf/Al Zubara",
     "wof:parent_id":85676773,
     "wof:placetype":"county",

--- a/data/110/875/794/9/1108757949.geojson
+++ b/data/110/875/794/9/1108757949.geojson
@@ -83,7 +83,10 @@
         1377149569
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"84"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"QA",
     "wof:created":1481308641,
     "wof:geom_alt":[
@@ -99,7 +102,7 @@
         }
     ],
     "wof:id":1108757949,
-    "wof:lastmodified":1694498067,
+    "wof:lastmodified":1695886174,
     "wof:name":"Umm Bab",
     "wof:parent_id":1377149569,
     "wof:placetype":"county",

--- a/data/110/875/795/1/1108757951.geojson
+++ b/data/110/875/795/1/1108757951.geojson
@@ -86,7 +86,10 @@
         1377149569
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"86"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"QA",
     "wof:created":1481308643,
     "wof:geom_alt":[
@@ -102,7 +105,7 @@
         }
     ],
     "wof:id":1108757951,
-    "wof:lastmodified":1694497897,
+    "wof:lastmodified":1695886025,
     "wof:name":"Dukhan",
     "wof:parent_id":1377149569,
     "wof:placetype":"county",

--- a/data/110/875/795/3/1108757953.geojson
+++ b/data/110/875/795/3/1108757953.geojson
@@ -50,7 +50,10 @@
         85676759
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"90"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"QA",
     "wof:created":1481308644,
     "wof:geom_alt":[
@@ -66,7 +69,7 @@
         }
     ],
     "wof:id":1108757953,
-    "wof:lastmodified":1694498182,
+    "wof:lastmodified":1695886523,
     "wof:name":"Al Wakra",
     "wof:parent_id":85676759,
     "wof:placetype":"county",

--- a/data/110/875/795/5/1108757955.geojson
+++ b/data/110/875/795/5/1108757955.geojson
@@ -50,7 +50,10 @@
         85676759
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"92"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"QA",
     "wof:created":1481308645,
     "wof:geom_alt":[
@@ -66,7 +69,7 @@
         }
     ],
     "wof:id":1108757955,
-    "wof:lastmodified":1694498182,
+    "wof:lastmodified":1695886523,
     "wof:name":"Messaid",
     "wof:parent_id":85676759,
     "wof:placetype":"county",

--- a/data/110/875/795/7/1108757957.geojson
+++ b/data/110/875/795/7/1108757957.geojson
@@ -53,7 +53,10 @@
         85676759
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"93"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"QA",
     "wof:created":1481308647,
     "wof:geom_alt":[
@@ -69,7 +72,7 @@
         }
     ],
     "wof:id":1108757957,
-    "wof:lastmodified":1694498182,
+    "wof:lastmodified":1695886523,
     "wof:name":"Mesaieed Industrial Area",
     "wof:parent_id":85676759,
     "wof:placetype":"county",

--- a/data/110/875/795/9/1108757959.geojson
+++ b/data/110/875/795/9/1108757959.geojson
@@ -53,7 +53,10 @@
         1377149573
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"96"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"QA",
     "wof:created":1481308648,
     "wof:geom_alt":[
@@ -69,7 +72,7 @@
         }
     ],
     "wof:id":1108757959,
-    "wof:lastmodified":1694498182,
+    "wof:lastmodified":1695886524,
     "wof:name":"Abu Samra",
     "wof:parent_id":1377149573,
     "wof:placetype":"county",

--- a/data/110/875/796/3/1108757963.geojson
+++ b/data/110/875/796/3/1108757963.geojson
@@ -50,7 +50,10 @@
         85676781
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"69"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"QA",
     "wof:created":1481308649,
     "wof:geom_alt":[
@@ -66,7 +69,7 @@
         }
     ],
     "wof:id":1108757963,
-    "wof:lastmodified":1694498184,
+    "wof:lastmodified":1695886532,
     "wof:name":"Jabal Thuaileb/Al Kharayej/Lusail/Al Egla/Wadi Al Banat",
     "wof:parent_id":85676781,
     "wof:placetype":"county",

--- a/data/110/875/805/7/1108758057.geojson
+++ b/data/110/875/805/7/1108758057.geojson
@@ -46,7 +46,10 @@
         1377149573
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"51"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"QA",
     "wof:created":1481308705,
     "wof:geomhash":"c607a6a9b01270d20a281e39b400cfed",
@@ -59,7 +62,7 @@
         }
     ],
     "wof:id":1108758057,
-    "wof:lastmodified":1694498069,
+    "wof:lastmodified":1695886247,
     "wof:name":"Al Gharrafa/Nasiriya/Izghawa/Bani Hajer",
     "wof:parent_id":1377149573,
     "wof:placetype":"county",

--- a/data/110/875/806/1/1108758061.geojson
+++ b/data/110/875/806/1/1108758061.geojson
@@ -46,7 +46,10 @@
         1377149573
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"52"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"QA",
     "wof:created":1481308707,
     "wof:geomhash":"803bbbbf08f31098f2c55e828b0f3228",
@@ -59,7 +62,7 @@
         }
     ],
     "wof:id":1108758061,
-    "wof:lastmodified":1694498069,
+    "wof:lastmodified":1695886247,
     "wof:name":"Al Luqta/Old Al Rayyan/Al Zaeem District",
     "wof:parent_id":1377149573,
     "wof:placetype":"county",

--- a/data/110/875/806/3/1108758063.geojson
+++ b/data/110/875/806/3/1108758063.geojson
@@ -46,7 +46,10 @@
         1377149573
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"53"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"QA",
     "wof:created":1481308709,
     "wof:geomhash":"1763baec50f3e6dbfbf383cc33486d24",
@@ -59,7 +62,7 @@
         }
     ],
     "wof:id":1108758063,
-    "wof:lastmodified":1694498074,
+    "wof:lastmodified":1695886360,
     "wof:name":"New Al Rayyan/Muaither North/Al Wajba",
     "wof:parent_id":1377149573,
     "wof:placetype":"county",

--- a/data/110/875/806/5/1108758065.geojson
+++ b/data/110/875/806/5/1108758065.geojson
@@ -46,7 +46,10 @@
         1377149573
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"54"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"QA",
     "wof:created":1481308710,
     "wof:geomhash":"38e268ccdc35923326762bab64485e1e",
@@ -59,7 +62,7 @@
         }
     ],
     "wof:id":1108758065,
-    "wof:lastmodified":1694498072,
+    "wof:lastmodified":1695886292,
     "wof:name":"Fereej Al Amir/Muraikh/Al Soudan North",
     "wof:parent_id":1377149573,
     "wof:placetype":"county",

--- a/data/110/875/806/7/1108758067.geojson
+++ b/data/110/875/806/7/1108758067.geojson
@@ -46,7 +46,10 @@
         1377149573
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"55"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"QA",
     "wof:created":1481308711,
     "wof:geomhash":"2f43c2977736e804a722e98e055f5dd1",
@@ -59,7 +62,7 @@
         }
     ],
     "wof:id":1108758067,
-    "wof:lastmodified":1694498070,
+    "wof:lastmodified":1695886248,
     "wof:name":"Al Soudan South/Al Waab/Al Aziziya",
     "wof:parent_id":1377149573,
     "wof:placetype":"county",

--- a/data/110/875/807/1/1108758071.geojson
+++ b/data/110/875/807/1/1108758071.geojson
@@ -46,7 +46,10 @@
         1377149573
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"56"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"QA",
     "wof:created":1481308712,
     "wof:geomhash":"277bc61f068181298c29e1f74f618c36",
@@ -59,7 +62,7 @@
         }
     ],
     "wof:id":1108758071,
-    "wof:lastmodified":1694498074,
+    "wof:lastmodified":1695886360,
     "wof:name":"New Al Khulaifat/Al Maamoura/Mesaimeer/Ain Khaled",
     "wof:parent_id":1377149573,
     "wof:placetype":"county",

--- a/data/110/875/808/3/1108758083.geojson
+++ b/data/110/875/808/3/1108758083.geojson
@@ -50,7 +50,10 @@
         85676767
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"76"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"QA",
     "wof:created":1481308719,
     "wof:geom_alt":[
@@ -66,7 +69,7 @@
         }
     ],
     "wof:id":1108758083,
-    "wof:lastmodified":1694498069,
+    "wof:lastmodified":1695886247,
     "wof:name":"Al Ghuwairiya",
     "wof:parent_id":85676767,
     "wof:placetype":"county",

--- a/data/110/875/808/5/1108758085.geojson
+++ b/data/110/875/808/5/1108758085.geojson
@@ -46,7 +46,10 @@
         1377149573
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"81"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"QA",
     "wof:created":1481308721,
     "wof:geomhash":"ceea5985b0ffbb522f551234340e4e75",
@@ -59,7 +62,7 @@
         }
     ],
     "wof:id":1108758085,
-    "wof:lastmodified":1694498074,
+    "wof:lastmodified":1695886348,
     "wof:name":"Mebaireek/Bu Nakhla",
     "wof:parent_id":1377149573,
     "wof:placetype":"county",

--- a/data/110/875/808/9/1108758089.geojson
+++ b/data/110/875/808/9/1108758089.geojson
@@ -53,7 +53,10 @@
         1377149573
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"83"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"QA",
     "wof:created":1481308722,
     "wof:geom_alt":[
@@ -69,7 +72,7 @@
         }
     ],
     "wof:id":1108758089,
-    "wof:lastmodified":1694498180,
+    "wof:lastmodified":1695886504,
     "wof:name":"Al Karaana",
     "wof:parent_id":1377149573,
     "wof:placetype":"county",

--- a/data/110/875/809/1/1108758091.geojson
+++ b/data/110/875/809/1/1108758091.geojson
@@ -46,7 +46,10 @@
         85676759
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"91"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"QA",
     "wof:created":1481308723,
     "wof:geomhash":"205b302f88f22ed0998d0f808bb16d6e",
@@ -59,7 +62,7 @@
         }
     ],
     "wof:id":1108758091,
-    "wof:lastmodified":1694498067,
+    "wof:lastmodified":1695886174,
     "wof:name":"Al Thumama / Al Wukair / Al Mashaf",
     "wof:parent_id":85676759,
     "wof:placetype":"county",

--- a/data/110/875/809/3/1108758093.geojson
+++ b/data/110/875/809/3/1108758093.geojson
@@ -50,7 +50,10 @@
         85676759
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"94"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"QA",
     "wof:created":1481308724,
     "wof:geom_alt":[
@@ -66,7 +69,7 @@
         }
     ],
     "wof:id":1108758093,
-    "wof:lastmodified":1694498075,
+    "wof:lastmodified":1695886397,
     "wof:name":"Shagra",
     "wof:parent_id":85676759,
     "wof:placetype":"county",

--- a/data/110/875/809/5/1108758095.geojson
+++ b/data/110/875/809/5/1108758095.geojson
@@ -49,7 +49,10 @@
         85676759
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"95"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"QA",
     "wof:created":1481308726,
     "wof:geomhash":"ed6ae6307474c5cf2d7dd8d42afa2adb",
@@ -62,7 +65,7 @@
         }
     ],
     "wof:id":1108758095,
-    "wof:lastmodified":1694498069,
+    "wof:lastmodified":1695886247,
     "wof:name":"Al Kharrara",
     "wof:parent_id":85676759,
     "wof:placetype":"county",

--- a/data/110/875/809/7/1108758097.geojson
+++ b/data/110/875/809/7/1108758097.geojson
@@ -53,7 +53,10 @@
         1377149573
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"97"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"QA",
     "wof:created":1481308727,
     "wof:geom_alt":[
@@ -69,7 +72,7 @@
         }
     ],
     "wof:id":1108758097,
-    "wof:lastmodified":1694498075,
+    "wof:lastmodified":1695886396,
     "wof:name":"Sawda Natheel",
     "wof:parent_id":1377149573,
     "wof:placetype":"county",

--- a/data/110/875/809/9/1108758099.geojson
+++ b/data/110/875/809/9/1108758099.geojson
@@ -50,7 +50,10 @@
         85676781
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"70"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"QA",
     "wof:created":1481308728,
     "wof:geom_alt":[
@@ -66,7 +69,7 @@
         }
     ],
     "wof:id":1108758099,
-    "wof:lastmodified":1694498069,
+    "wof:lastmodified":1695886247,
     "wof:name":"Al Ebaib/Al Ebb/Al Kheesa/Lusail/Umm Qarn",
     "wof:parent_id":85676781,
     "wof:placetype":"county",

--- a/data/110/875/810/1/1108758101.geojson
+++ b/data/110/875/810/1/1108758101.geojson
@@ -46,7 +46,10 @@
         85676777
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"71"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"QA",
     "wof:created":1481308729,
     "wof:geomhash":"12b8b3840bee999311c7edfa4542a862",
@@ -59,7 +62,7 @@
         }
     ],
     "wof:id":1108758101,
-    "wof:lastmodified":1694498069,
+    "wof:lastmodified":1695886247,
     "wof:name":"Al Kharaitiyat/Izghawa/Umm Slal/Umm Al Amad/Umm Obiri",
     "wof:parent_id":85676777,
     "wof:placetype":"county",

--- a/data/110/875/810/3/1108758103.geojson
+++ b/data/110/875/810/3/1108758103.geojson
@@ -50,7 +50,10 @@
         85676773
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"77"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"QA",
     "wof:created":1481308730,
     "wof:geom_alt":[
@@ -66,7 +69,7 @@
         }
     ],
     "wof:id":1108758103,
-    "wof:lastmodified":1694498072,
+    "wof:lastmodified":1695886292,
     "wof:name":"Fuwairit/Ain Sinan/Madinat Al Kaaban",
     "wof:parent_id":85676773,
     "wof:placetype":"county",

--- a/data/110/875/810/7/1108758107.geojson
+++ b/data/110/875/810/7/1108758107.geojson
@@ -50,7 +50,10 @@
         1377149569
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"73"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"QA",
     "wof:created":1481308731,
     "wof:geom_alt":[
@@ -66,7 +69,7 @@
         }
     ],
     "wof:id":1108758107,
-    "wof:lastmodified":1694498182,
+    "wof:lastmodified":1695886520,
     "wof:name":"Lijmiliya",
     "wof:parent_id":1377149569,
     "wof:placetype":"county",

--- a/data/110/875/810/9/1108758109.geojson
+++ b/data/110/875/810/9/1108758109.geojson
@@ -50,7 +50,10 @@
         85676773
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"79"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"QA",
     "wof:created":1481308732,
     "wof:geom_alt":[
@@ -66,7 +69,7 @@
         }
     ],
     "wof:id":1108758109,
-    "wof:lastmodified":1694498067,
+    "wof:lastmodified":1695886174,
     "wof:name":"Al Ruwais / Madinat Al Shamal",
     "wof:parent_id":85676773,
     "wof:placetype":"county",

--- a/data/110/875/811/1/1108758111.geojson
+++ b/data/110/875/811/1/1108758111.geojson
@@ -50,7 +50,10 @@
         85676759
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"98"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"QA",
     "wof:created":1481308733,
     "wof:geom_alt":[
@@ -66,7 +69,7 @@
         }
     ],
     "wof:id":1108758111,
-    "wof:lastmodified":1694498181,
+    "wof:lastmodified":1695886509,
     "wof:name":"Al Adaid",
     "wof:parent_id":85676759,
     "wof:placetype":"county",

--- a/data/110/875/811/5/1108758115.geojson
+++ b/data/110/875/811/5/1108758115.geojson
@@ -46,7 +46,10 @@
         1377149569
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"80"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"QA",
     "wof:created":1481308736,
     "wof:geomhash":"7cced562b9c3e6f0496506de0efa1d98",
@@ -59,7 +62,7 @@
         }
     ],
     "wof:id":1108758115,
-    "wof:lastmodified":1694498070,
+    "wof:lastmodified":1695886249,
     "wof:name":"Al Sheehaniya",
     "wof:parent_id":1377149569,
     "wof:placetype":"county",

--- a/data/110/875/811/7/1108758117.geojson
+++ b/data/110/875/811/7/1108758117.geojson
@@ -49,7 +49,10 @@
         1377149569
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"82"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"QA",
     "wof:created":1481308737,
     "wof:geomhash":"63ed22372520ec33a3aea35f60fa364e",
@@ -62,7 +65,7 @@
         }
     ],
     "wof:id":1108758117,
-    "wof:lastmodified":1694498075,
+    "wof:lastmodified":1695886391,
     "wof:name":"Rawdat Rashed",
     "wof:parent_id":1377149569,
     "wof:placetype":"county",

--- a/data/110/875/811/9/1108758119.geojson
+++ b/data/110/875/811/9/1108758119.geojson
@@ -52,7 +52,10 @@
         1377149569
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"85"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"QA",
     "wof:created":1481308738,
     "wof:geomhash":"ada2de6ac1353d60156ac57c41e5705b",
@@ -65,7 +68,7 @@
         }
     ],
     "wof:id":1108758119,
-    "wof:lastmodified":1694498069,
+    "wof:lastmodified":1695886247,
     "wof:name":"Al Nasraniya",
     "wof:parent_id":1377149569,
     "wof:placetype":"county",

--- a/data/110/875/812/1/1108758121.geojson
+++ b/data/110/875/812/1/1108758121.geojson
@@ -50,7 +50,10 @@
         85676767
     ],
     "wof:breaches":[],
-    "wof:concordances":{},
+    "wof:concordances":{
+        "meso:local_id":"74"
+    },
+    "wof:concordances_official":"meso:local_id",
     "wof:country":"QA",
     "wof:created":1481308739,
     "wof:geom_alt":[
@@ -66,7 +69,7 @@
         }
     ],
     "wof:id":1108758121,
-    "wof:lastmodified":1694498070,
+    "wof:lastmodified":1695886248,
     "wof:name":"Al Khor/Al Daayen/Simaisma/Al Jeryan/Al Sunay",
     "wof:parent_id":85676767,
     "wof:placetype":"county",

--- a/data/137/714/956/9/1377149569.geojson
+++ b/data/137/714/956/9/1377149569.geojson
@@ -72,8 +72,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gn:id":289877,
+        "iso:code":"QA-SH",
         "wk:page":"Al-Shahaniya"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"QA",
     "wof:geomhash":"54e7903855dbd3de1a1c60eae1a35a88",
     "wof:hierarchy":[
@@ -90,7 +92,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1694493129,
+    "wof:lastmodified":1695884325,
     "wof:name":"Al-Shahaniya",
     "wof:parent_id":85632299,
     "wof:placetype":"region",

--- a/data/137/714/957/3/1377149573.geojson
+++ b/data/137/714/957/3/1377149573.geojson
@@ -256,11 +256,13 @@
         "gn:id":389469,
         "gp:id":20070010,
         "hasc:id":"QA.RY",
+        "iso:code":"QA-RA",
         "iso:id":"QA-RA",
         "qs_pg:id":355519,
         "unlc:id":"QA-RA",
         "wd:id":"Q311272"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"QA",
     "wof:geomhash":"7af2ecac9b68ad1c039046ac0530f96d",
     "wof:hierarchy":[
@@ -277,7 +279,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1694493179,
+    "wof:lastmodified":1695884552,
     "wof:name":"Ar Rayyan",
     "wof:parent_id":85632299,
     "wof:placetype":"region",

--- a/data/137/714/969/9/1377149699.geojson
+++ b/data/137/714/969/9/1377149699.geojson
@@ -694,7 +694,7 @@
         }
     ],
     "wof:id":1377149699,
-    "wof:lastmodified":1694497833,
+    "wof:lastmodified":1695886843,
     "wof:name":"Doha",
     "wof:parent_id":85676749,
     "wof:placetype":"county",

--- a/data/856/322/99/85632299.geojson
+++ b/data/856/322/99/85632299.geojson
@@ -1191,6 +1191,7 @@
         "hasc:id":"QA",
         "icao:code":"A7",
         "ioc:id":"QAT",
+        "iso:code":"QA",
         "itu:id":"QAT",
         "loc:id":"n79077269",
         "m49:code":"634",
@@ -1205,6 +1206,7 @@
         "wk:page":"Qatar",
         "wmo:id":"QT"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"QA",
     "wof:country_alpha3":"QAT",
     "wof:geom_alt":[
@@ -1227,7 +1229,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1694639559,
+    "wof:lastmodified":1695881217,
     "wof:name":"Qatar",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/767/49/85676749.geojson
+++ b/data/856/767/49/85676749.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.019547,
-    "geom:area_square_m":218562971.888009,
+    "geom:area_square_m":218562751.975359,
     "geom:bbox":"51.397751,25.151949,51.647362,25.396163",
     "geom:latitude":25.275372,
     "geom:longitude":51.520838,
@@ -626,11 +626,13 @@
         "gn:id":389470,
         "gp:id":20070008,
         "hasc:id":"QA.DA",
+        "iso:code":"QA-DA",
         "iso:id":"QA-DA",
         "qs_pg:id":355527,
         "unlc:id":"QA-DA",
         "wd:id":"Q3861"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         421190363,
         1377149699
@@ -640,7 +642,7 @@
         "quattroshapes",
         "meso"
     ],
-    "wof:geomhash":"2ddd2ab49a9aec75a5b1bd13aab2a10b",
+    "wof:geomhash":"ea68314885a56a14097fe464cd06e227",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -655,7 +657,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690857376,
+    "wof:lastmodified":1695884405,
     "wof:name":"Ad Dawhah",
     "wof:parent_id":85632299,
     "wof:placetype":"region",

--- a/data/856/767/59/85676759.geojson
+++ b/data/856/767/59/85676759.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.227453,
-    "geom:area_square_m":2551821257.609478,
+    "geom:area_square_m":2551821257.60913,
     "geom:bbox":"51.086810362,24.4736679464,51.63155375,25.2158656974",
     "geom:latitude":24.862594,
     "geom:longitude":51.337592,
@@ -236,16 +236,18 @@
         "gn:id":389472,
         "gp:id":20070012,
         "hasc:id":"QA.WA",
+        "iso:code":"QA-WA",
         "iso:id":"QA-WA",
         "qs_pg:id":425211,
         "unlc:id":"QA-WA"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"QA",
     "wof:geom_alt":[
         "quattroshapes",
         "meso"
     ],
-    "wof:geomhash":"d848d2e75378bf00cbd786750f8b8b34",
+    "wof:geomhash":"a8ede9b166ff23742f47db7226c60446",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -260,7 +262,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1582360329,
+    "wof:lastmodified":1695884374,
     "wof:name":"Al Wakrah",
     "wof:parent_id":85632299,
     "wof:placetype":"region",

--- a/data/856/767/67/85676767.geojson
+++ b/data/856/767/67/85676767.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.144862,
-    "geom:area_square_m":1612905118.447492,
+    "geom:area_square_m":1612905092.843231,
     "geom:bbox":"50.9556,25.559185,51.621163,25.966227",
     "geom:latitude":25.783895,
     "geom:longitude":51.335062,
@@ -296,16 +296,18 @@
         "gn:id":389465,
         "gp:id":20070006,
         "hasc:id":"QA.KR",
+        "iso:code":"QA-KH",
         "iso:id":"QA-KH",
         "qs_pg:id":425210,
         "wd:id":"Q1156471"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"QA",
     "wof:geom_alt":[
         "quattroshapes",
         "meso"
     ],
-    "wof:geomhash":"9b84fad35702903b895bd221547db946",
+    "wof:geomhash":"5a30c928b52ec9d9bc15a1d46abf2fe5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -320,7 +322,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690857375,
+    "wof:lastmodified":1695884374,
     "wof:name":"Al Khor",
     "wof:parent_id":85632299,
     "wof:placetype":"region",

--- a/data/856/767/73/85676773.geojson
+++ b/data/856/767/73/85676773.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.077422,
-    "geom:area_square_m":860482059.623897,
+    "geom:area_square_m":860482221.943265,
     "geom:bbox":"50.958843,25.844616,51.448446,26.184029",
     "geom:latitude":25.9952,
     "geom:longitude":51.20126,
@@ -156,16 +156,18 @@
         "gn:id":389462,
         "gp:id":20070005,
         "hasc:id":"QA.MS",
+        "iso:code":"QA-MS",
         "iso:id":"QA-MS",
         "qs_pg:id":220139,
         "unlc:id":"QA-MS"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"QA",
     "wof:geom_alt":[
         "meso",
         "quattroshapes"
     ],
-    "wof:geomhash":"8b2d92c9b3adfcdca37801a93ed02e89",
+    "wof:geomhash":"94e7d87a9dfee473092e742e36b25e01",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -180,7 +182,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1636503123,
+    "wof:lastmodified":1695884951,
     "wof:name":"Madinat ach Shamal",
     "wof:parent_id":85632299,
     "wof:placetype":"region",

--- a/data/856/767/77/85676777.geojson
+++ b/data/856/767/77/85676777.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.028423,
-    "geom:area_square_m":317300386.159834,
+    "geom:area_square_m":317300275.114509,
     "geom:bbox":"51.260323,25.352175,51.446444,25.589874",
     "geom:latitude":25.469499,
     "geom:longitude":51.343868,
@@ -291,16 +291,18 @@
         "gn:id":389467,
         "gp:id":20070007,
         "hasc:id":"QA.SL",
+        "iso:code":"QA-US",
         "iso:id":"QA-US",
         "qs_pg:id":364434,
         "wd:id":"Q990414"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"QA",
     "wof:geom_alt":[
         "quattroshapes",
         "meso"
     ],
-    "wof:geomhash":"b01721eb2a961fab21ba1bfebc2d6f36",
+    "wof:geomhash":"12b8b3840bee999311c7edfa4542a862",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -315,7 +317,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690857375,
+    "wof:lastmodified":1695884951,
     "wof:name":"Umm Salal",
     "wof:parent_id":85632299,
     "wof:placetype":"region",

--- a/data/856/767/81/85676781.geojson
+++ b/data/856/767/81/85676781.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.025638,
-    "geom:area_square_m":286109594.46716,
+    "geom:area_square_m":286109751.911256,
     "geom:bbox":"51.403799,25.368321,51.575417,25.653665",
     "geom:latitude":25.510707,
     "geom:longitude":51.464667,
@@ -322,15 +322,17 @@
         "gn:id":8030540,
         "gp:id":-20070007,
         "hasc:id":"QA.DY",
+        "iso:code":"QA-ZA",
         "iso:id":"QA-ZA",
         "wd:id":"Q990414"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"QA",
     "wof:geom_alt":[
         "quattroshapes",
         "meso"
     ],
-    "wof:geomhash":"bab9c9e9887df87cee6791d0012fea4c",
+    "wof:geomhash":"9021cf4dac181ef057e3927235b36d0a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -345,7 +347,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690857375,
+    "wof:lastmodified":1695884951,
     "wof:name":"Al Daayen",
     "wof:parent_id":85632299,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.